### PR TITLE
Better error handling; simpler code

### DIFF
--- a/library/src/blas_ex/rocblas_gemm_ex.hpp
+++ b/library/src/blas_ex/rocblas_gemm_ex.hpp
@@ -748,7 +748,7 @@ rocblas_status gemm_ex_handle_transpose(rocblas_handle    handle,
                                         unsigned(k),
                                         handle->rocblas_stream, GetTransposeMode(trans_a, trans_b));
     }
-    
+
 
     rb_status = (t_status == tensileStatusSuccess) ? rocblas_status_success : rocblas_status_internal_error;
     return rb_status;
@@ -918,21 +918,16 @@ rocblas_status gemm_ex_typecasting(rocblas_handle    handle,
     Tc h_alpha[1];
     Tc h_beta[1];
 
+    if(stride_alpha || stride_beta)
+        return rocblas_status_not_implemented;
+
     if(rocblas_pointer_mode_device == handle->pointer_mode)
     {
-        // copy alpha and beta from device to host and convert type
-        for(int b = 0; b < 1; b++)
-            hipMemcpy(&h_alpha[b], (Tc*)alpha + b * stride_alpha, sizeof(Tc), hipMemcpyDeviceToHost);
-        
-        for(int b = 0; b < 1; b++)
-            hipMemcpy(&h_beta[b], (Tc*)beta + b * stride_beta, sizeof(Tc), hipMemcpyDeviceToHost);
-    }
-    else
-    {
-        for(int b = 0; b < 1; b++)
-            h_alpha[b] = *(((const Tc*)alpha) + b * stride_alpha);
-        for(int b = 0; b < 1; b++)
-            h_beta[b] = *(((const Tc*)beta) + b * stride_beta);
+        // copy alpha and beta from device to host
+        RETURN_IF_HIP_ERROR(hipMemcpy(h_alpha, alpha, sizeof(Tc), hipMemcpyDeviceToHost));
+        RETURN_IF_HIP_ERROR(hipMemcpy(h_beta, beta, sizeof(Tc), hipMemcpyDeviceToHost));
+        alpha = h_alpha;
+        beta = h_beta;
     }
 
     // check alignment of pointers before casting
@@ -949,7 +944,7 @@ rocblas_status gemm_ex_typecasting(rocblas_handle    handle,
                                 unsigned(m),
                                 unsigned(n),
                                 unsigned(k),
-                                h_alpha,
+                                (Tc*)alpha,
                                 0, // using stride of 1 for alpha
                                 (const Ti**)a,
                                 unsigned(offsetAin),
@@ -959,7 +954,7 @@ rocblas_status gemm_ex_typecasting(rocblas_handle    handle,
                                 unsigned(offsetBin),
                                 unsigned(ldb),
                                 unsigned(stride_b),
-                                h_beta,
+                                (Tc*)beta,
                                 0, // using stride of 1 for beta
                                 (const To**)c,
                                 unsigned(offsetCin),
@@ -983,7 +978,7 @@ rocblas_status gemm_ex_typecasting(rocblas_handle    handle,
                                 unsigned(m),
                                 unsigned(n),
                                 unsigned(k),
-                                h_alpha,
+                                (Tc*)alpha,
                                 0,
                                 (const Ti*)a,
                                 unsigned(offsetAin),
@@ -993,7 +988,7 @@ rocblas_status gemm_ex_typecasting(rocblas_handle    handle,
                                 unsigned(offsetBin),
                                 unsigned(ldb),
                                 unsigned(stride_b),
-                                h_beta,
+                                (Tc*)beta,
                                 0,
                                 (const To*)c,
                                 unsigned(offsetCin),
@@ -1006,7 +1001,7 @@ rocblas_status gemm_ex_typecasting(rocblas_handle    handle,
                                 unsigned(batch_count));
     }
 
-    
+
 }
 
 #endif


### PR DESCRIPTION
```
    if(stride_alpha || stride_beta)
        return rocblas_status_not_implemented;
```
(The above is to avoid surprises while the code still halfway supports `stride_alpha` and `stride_beta`.)

Use `RETURN_IF_HIP_ERROR()` around Hip calls

Simpler code for handling `alpha`, `beta`, `alpha_h`, `beta_h`
